### PR TITLE
(fix): move cordova.js to end of body tag

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -15,9 +15,6 @@
     <!-- ionic/angularjs js -->
     <script src="lib/ionic/js/ionic.bundle.js"></script>
 
-    <!-- cordova script (this will be a 404 during development) -->
-    <script src="cordova.js"></script>
-
     <!-- your app's js -->
     <script src="js/app.js"></script>
   </head>
@@ -30,5 +27,8 @@
       <ion-content class="has-header">
       </ion-content>
     </ion-pane>
+    
+    <!-- cordova script (this will be a 404 during development) -->
+    <script src="cordova.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The cordova.js file must be at the bottom of the body tag.

There should be no breaking changes associated with this fix. Fixes driftyco/ionic#1751
