### PR TITLE
Run sass before starting watcher

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ gulp.task('sass', function(done) {
     .on('end', done);
 });
 
-gulp.task('watch', function() {
+gulp.task('watch', ['sass'], function() {
   gulp.watch(paths.sass, ['sass']);
 });
 


### PR DESCRIPTION
This is just a simple change to make the watch task run the sass task first, so if you edit a file then start the watch task, it will rebuild immediately to ensure the css was built from the start.
