### PR TITLE
Bumping gulp-sass to be 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An Ionic project",
   "dependencies": {
     "gulp": "^3.5.6",
-    "gulp-sass": "^0.7.1",
+    "gulp-sass": "^1.3.3",
     "gulp-concat": "^2.2.0",
     "gulp-minify-css": "^0.3.0",
     "gulp-rename": "^1.2.0"


### PR DESCRIPTION
Bumping gulp-sass to be 1.3.3 will ensure node-sass 2.x is installed which fixes some sass issues windows users may run into.