### PR TITLE
Pipe sass errors to console to keep watch running

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,9 @@ gulp.task('default', ['sass']);
 
 gulp.task('sass', function(done) {
   gulp.src('./scss/ionic.app.scss')
-    .pipe(sass())
+    .pipe(sass({
+      errLogToConsole: true
+    }))
     .pipe(gulp.dest('./www/css/'))
     .pipe(minifyCss({
       keepSpecialComments: 0


### PR DESCRIPTION
Right now, if a sass error occurs the `gulp sass` task throws an error, and hangs. By passing `{ errLogToConsole: true }` to the sass task, it forwards the errors to the console and the task finishes by sending the error to the console and continuing the `watch` task.