### PR TITLE
allow ECMAScript 6 usage via babeljs

### DIFF
--- a/es6/app.js
+++ b/es6/app.js
@@ -1,0 +1,26 @@
+// Ionic Starter App using ECMAScript 6
+
+// angular.module is a global place for creating, registering and retrieving Angular modules
+// 'starter' is the name of this angular module example (also set in a <body> attribute in index.html)
+// the 2nd parameter is an array of 'requires'
+angular.module('starter', ['ionic'])
+
+.run(($ionicPlatform) => {
+  $ionicPlatform.ready(() => {
+    // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
+    // for form inputs).
+    // The reason we default this to hidden is that native apps don't usually show an accessory bar, at
+    // least on iOS. It's a dead giveaway that an app is using a Web View. However, it's sometimes
+    // useful especially with forms, though we would prefer giving the user a little more room
+    // to interact with the app.
+    if(window.cordova && window.cordova.plugins.Keyboard) {
+      cordova.plugins.Keyboard.hideKeyboardAccessoryBar(true);
+    }
+    if(window.StatusBar) {
+      // Set the statusbar to use the default style, tweak this to
+      // remove the status bar on iOS or change it to use white instead of dark colors.
+      StatusBar.styleDefault();
+    }
+  });
+});
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,12 +6,21 @@ var sass = require('gulp-sass');
 var minifyCss = require('gulp-minify-css');
 var rename = require('gulp-rename');
 var sh = require('shelljs');
+var babel = require('gulp-babel');
 
 var paths = {
+  js: ['./es6/**/*.js'],
   sass: ['./scss/**/*.scss']
 };
 
 gulp.task('default', ['sass']);
+
+gulp.task('babel', function(done) {
+  gulp.src('./es6/*.js')
+    .pipe(babel())
+    .pipe(gulp.dest('./www/js/'))
+    .on('end', done);
+});
 
 gulp.task('sass', function(done) {
   gulp.src('./scss/ionic.app.scss')
@@ -29,6 +38,7 @@ gulp.task('sass', function(done) {
 
 gulp.task('watch', function() {
   gulp.watch(paths.sass, ['sass']);
+  gulp.watch(paths.js, ['babel']);
 });
 
 gulp.task('install', ['git-check'], function() {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "bower": "^1.3.3",
     "gulp-util": "^2.2.14",
-    "shelljs": "^0.3.0"
+    "shelljs": "^0.3.0",
+    "gulp-babel": "~5.1.0"
   }
 }


### PR DESCRIPTION
This PR add a "babel" grunt task, and an `es6` folder (we can discuss the name if you want).

The babel task automatically compile the es6 files to the `www/js/` folder.

I recreate the `app.js` file with a little change (arrow functions) to make an example.

Thanks !