### PR TITLE
Ignored directories generated by Cordova

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 node_modules/
 platforms/
 plugins/
+resources/
+hooks/
+www/lib/


### PR DESCRIPTION
Eventually if android or ios build are generated for any ionic app, resources directory is added, which contains dummy icons and splash screen for ios and Android. In addition I have also ignored hooks directory (don't know what it is) and www/lib directory which contains all the initial angular modules.
